### PR TITLE
Update kira.js  - fixing TypeError: Object #<Object> has no method 'random'

### DIFF
--- a/lib/kira.js
+++ b/lib/kira.js
@@ -235,5 +235,5 @@ Api.prototype.getReferer = function getReferer() {
         'https://' + utils.uniqueToken() + '.gl',
         'https://' + utils.uniqueToken() + '.uk',
         'https://' + utils.uniqueToken() + '.tk'
-    ][utils.random(0, 12)];
+    ][utils.getRandomInt(0, 12)];
 };


### PR DESCRIPTION
Replacing utils.random() with getRandomInt() and fixing issue:

TypeError: Object #<Object> has no method 'random'
    at Api.getReferer (/root/tmp/node_modules/kira/lib/kira.js:238:13)
    at attack (/root/tmp/node_modules/kira/lib/kira.js:147:42)
    at wrapper [as _onTimeout](timers.js:261:14)
    at Timer.listOnTimeout [as ontimeout](timers.js:112:15)
